### PR TITLE
select amount of work before selecting subscription

### DIFF
--- a/glueckhof/settings.py
+++ b/glueckhof/settings.py
@@ -51,6 +51,8 @@ DATABASES = {
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [os.path.join(BASE_DIR, 'templates')],
+        'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
                 'django.contrib.auth.context_processors.auth',
@@ -62,11 +64,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.messages.context_processors.messages',
             ],
-            'loaders': [
-                'django.template.loaders.filesystem.Loader',
-                'django.template.loaders.app_directories.Loader'
-            ],
-            'debug' : True
+            'debug': DEBUG
         },
     },
 ]

--- a/templates/createsubscription/select_subscription.html
+++ b/templates/createsubscription/select_subscription.html
@@ -1,0 +1,31 @@
+{% extends "createsubscription/select_subscription.html" %}
+{% load i18n %}
+{% load static %}
+{% load juntagrico.config %}
+{% load crispy_forms_tags %}
+{% block allcontent %}
+    <div class="offset-md-2 col-md-8">
+        <h4>Wähle deine Mitarbeit pro Jahr</h4>
+        <p>Pro Halbtag (4 Stunden) weniger Mitarbeit steigt der Beitrag um CHF 50.</p>
+        <div class="row">
+            <div class="col-md-3">
+                <input type="number" name="work" value="40" min="8" max="40" step="4" required="" id="work" onchange="
+                    for (let element of document.getElementsByClassName('subs-type-row')){
+                       element.style.display='none';
+                       $(element.querySelector('input')).val(0).change();
+                    }
+                    for (let element of document.getElementsByClassName('type-req-' + this.value)){
+                       element.style.display='';
+                    }
+                ">
+            </div>
+            <div class="col-md-9">
+                <p>Stunden Mitarbeit pro Jahr.</p>
+            </div>
+        </div>
+    </div>
+    <div class="offset-md-2 col-md-8">
+        <h4>Wähle die Grösse deines Ernte-Anteils</h4>
+        {% crispy form %}
+    </div>
+{% endblock %}

--- a/templates/forms/subscription_type_field.html
+++ b/templates/forms/subscription_type_field.html
@@ -1,0 +1,41 @@
+{% load i18n %}
+{% load juntagrico.common %}
+{% load juntagrico.config %}
+{% load crispy_forms_field %}
+<div class="form-group row subs-type-row type-req-{{ type.required_assignments }}" {% if type.required_assignments < 40 %}style="display: none;"{% endif %}>
+    <div class="col-md-3">
+        {{ field }}
+    </div>
+    <label for="type{{ type.id }}" class="col-md-9">
+        {% if type.long_name.strip %}
+            <strong>{{ type.long_name }}</strong>
+            <br/>
+        {% endif %}
+        {% if type.description.strip %}
+            {{ type.description|richtext|safe }}
+            <br/>
+        {% endif %}
+        {% if type.has_periods %}
+            {% vocabulary "price" %}:
+            {% for period in type.periods.all %}
+                <br/>
+                {{ period.start_day }}.{{ period.start_month }}. - {{ period.end_day }}.{{ period.end_month }}.
+                {{ period.price }} {% config "currency" %}
+            {% endfor %}
+        {% else %}
+            {% vocabulary "price" %}: {{ type.price }} {% config "currency" %}
+            <br/>
+            {% trans "Laufzeit" %}: {{ type.min_duration_info }}
+        {% endif %}
+        {% config "enable_shares" as c_enable_shares %}
+        {% if c_enable_shares %}
+            <br/>
+            {% vocabulary "share_pl" %}: {{ type.shares }}
+        {% endif %}
+        <br/>
+        {% trans "Arbeitseinsätze" %}: {{ type.required_assignments }}
+        {% if hours_used %}
+            {% trans "Stunden" %}
+        {% endif %}
+    </label>
+</div>


### PR DESCRIPTION
Hier ein erster Versuch um die Auswahl des Ernte-Anteil-Typs bei der Bestellung zu vereinfachen.
Oben kann die Mitarbeit in Stunden in 4er-Schritten eingestellt werden und unten werden dann nur die 3 Grössen mit der entsprechenden Mitarbeit angeboten.

![grafik](https://github.com/itglueckhof/Juntagrico/assets/1621900/d81aeeac-1cc4-4bfe-a990-fc706b4a00ba)
